### PR TITLE
Fix/ngram

### DIFF
--- a/dhlab/ngram/nb_ngram.py
+++ b/dhlab/ngram/nb_ngram.py
@@ -10,6 +10,7 @@ def nb_ngram(terms: str,
              mode: str = 'relative',
             lang: str = 'nob'):
     """Extract N-gram frequencies from given ``terms`` and ``years``.
+    `lang` param is not supported for corpus=`avis` and will be set to None if `avis` is passed.
 
     :param terms: comma
     :param corpus:
@@ -21,6 +22,10 @@ def nb_ngram(terms: str,
 
     :meta private:
     """
+    # Set default lang for 'bok'-corpus
+    if corpus == "avis":
+        lang = None
+    
     df = ngram_conv(get_ngram(terms, corpus=corpus, lang = lang), smooth=smooth, years=years, mode=mode)
     df.index = df.index.astype(int)
     return df.sort_index()

--- a/dhlab/ngram/ngram.py
+++ b/dhlab/ngram/ngram.py
@@ -7,7 +7,34 @@ from dhlab.ngram.nb_ngram import nb_ngram
 class Ngram:
     """Top level class for ngrams"""
 
-    def __init__(self, words=None, from_year=None, to_year=None, doctype=None, mode='relative', lang='nob') -> None:
+    def __init__(self,
+                 words=None,
+                 from_year=None,
+                 to_year=None,
+                 doctype='bok',
+                 mode='relative',
+                 lang="nob"
+                 ):
+        """Ngram builder class.
+
+        Build Ngrams from the National Librarys collections.
+        Use with book corpus or newspaper corpus.
+        Lang parameter is only supported for book (`bok`) corpus. 
+        Defaults to `None` if doctype is `avis`.
+
+        :param words: words to examine, defaults to None
+        :type words: str or list of str, optional
+        :param from_year: lower period cutoff, defaults to None
+        :type from_year: int, optional
+        :param to_year: upper period cutoff, defaults to None
+        :type to_year: int, optional
+        :param doctype: `bok` or `avis` , defaults to 'bok'
+        :type doctype: str, optional
+        :param mode: Frequency measure, defaults to 'relative'
+        :type mode: str, optional
+        :param lang: `nob`, `nno`. Only use with docytype='bok', defaults to 'nob'
+        :type lang: str, optional
+        """
 
         self.date = datetime.now()
         if to_year is None:
@@ -19,6 +46,7 @@ class Ngram:
         self.to_year = to_year
         self.words = words
         self.lang = lang
+
         if not doctype is None:
             if 'bok' in doctype:
                 doctype = 'bok'
@@ -28,7 +56,17 @@ class Ngram:
                 doctype = 'bok'
         else:
             doctype = 'bok'
-        ngrm = nb_ngram(terms=', '.join(words), corpus=doctype, years=(from_year, to_year), smooth = 1, lang = lang, mode=mode)
+
+        # Set default lang for 'bok'-corpus
+        if doctype == "avis":
+            lang = None
+
+
+        ngrm = nb_ngram(terms=', '.join(words),
+                        corpus=doctype,
+                        years=(from_year, to_year),
+                        smooth = 1, lang = lang,
+                        mode=mode)
         ngrm.index = ngrm.index.astype(str)
         self.ngram = ngrm
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,5 @@ python_louvain == 0.16
 requests == 2.27.1
 seaborn == 0.11.2
 wordcloud == 1.8.1
+scipy == 1.9.3
 spacy # added 13 juli 2022


### PR DESCRIPTION
Ngram med doctype avis støtter ikke lang parameteret. Denne fixen setter lang til None hvis avis settes.

Jeg har her valgt å beholde "bok" som default parameter, for så i stedet overskrive dette hvis docype er avis. Jeg opplevde at hvis dette markeres tydelig i dokumentasjonen så er dette det mest oversiktlige og transparante. Hva tenker dere? 

Alternativet er å sette default til None f.eks.