### PR TITLE
fix: upgrade python requirements in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dhlab"
-version = "2.28.3"  # Placeholder for the poetry-dynamic-versioning plugin
+version = "2.28.3"
 description = "Text and image analysis of the digital collection (books, newspapers, periodicals, and images) at the National Library of Norway"
 authors = ["The Digital Humanities Lab at The National Library of Norway (NB) <dh-lab@nb.no>"]
 license = "MIT"
@@ -22,7 +22,7 @@ exclude = ["docs/", "tests/"]
 "Tutorials" = "https://nationallibraryofnorway.github.io/digital_tekstanalyse/tutorial.html"
 
 [tool.poetry.dependencies]
-python = ">=3.8,<3.13"
+python = ">=3.9,<3.13"
 ipython = "^8.17.2"
 matplotlib = "^3.8.1"
 networkx = "^3.2.1"


### PR DESCRIPTION
Read the Docs failed to build the documentation while the python requirement allowed for version 3.8, which is incompatible with Sphinx 7.2.6.  DHLAB now requires python>=3.9