### PR TITLE
Feat/sparse

### DIFF
--- a/dhlab/text/conc_coll.py
+++ b/dhlab/text/conc_coll.py
@@ -168,12 +168,13 @@ class Collocations(DhlabObj):
 class Counts(DhlabObj):
     """Provide counts for a corpus - shouldn't be too large"""
 
-    def __init__(self, corpus=None, words=None, cutoff=0):
+    def __init__(self, corpus=None, words=None, cutoff=0, sparse=False):
         """Get frequency list for Corpus
 
         :param corpus: target Corpus, defaults to None
         :param words: list of words to be counted, defaults to None
         :param cutoff: frequency cutoff, will not include words with frequency < cutoff
+        :param sparse: return a sparse matrix for memory efficiency
         """
         if corpus is None and words is None:
             self.freq = pd.DataFrame()
@@ -190,7 +191,7 @@ class Counts(DhlabObj):
             # count - if words is none result will be as if counting all words
             # in the corpus
             self.freq = get_document_frequencies(
-                urns=urnlist(corpus), cutoff=cutoff, words=words
+                urns=urnlist(corpus), cutoff=cutoff, words=words, sparse=sparse
             )
 
             # Include dhlab and title link in object

--- a/dhlab/text/conc_coll.py
+++ b/dhlab/text/conc_coll.py
@@ -209,12 +209,34 @@ class Counts(DhlabObj):
 
         super().__init__(self.freq)
 
+    def is_sparse(self):
+        """Function to report sparsity of counts frame"""
+        try:
+            density = self.freq.sparse.density
+            if density:
+                sparse = True
+            else:
+                sparse = False
+        except:
+            sparse = False
+        return sparse
+
     def sum(self):
         """Summarize Corpus frequencies
-
         :return: frequency list for Corpus
         """
-        return self.from_df(self.counts.sum(axis=1).to_frame("freq"))
+
+        # Needed since Pandas seems to make sparse matrices dense when summing
+        if self.is_sparse() == True:
+            freqDict = dict()
+            for x in self.freq.iterrows():
+                freqDict[x[0]] = x[1].sum()
+
+            df = pd.DataFrame(freqDict.items(), columns=["word", "freq"]).set_index("word")
+            df.index.name = None
+            return self.from_df(df)
+        else:
+            return self.from_df(self.counts.sum(axis=1).to_frame("freq"))
 
     def display_names(self):
         "Display data with record names as column titles."

--- a/dhlab/text/conc_coll.py
+++ b/dhlab/text/conc_coll.py
@@ -173,7 +173,7 @@ class Counts(DhlabObj):
 
         :param corpus: target Corpus, defaults to None
         :param words: list of words to be counted, defaults to None
-        :param cutoff: frequency cutoff, will not include words with frequency <= cutoff
+        :param cutoff: frequency cutoff, will not include words with frequency < cutoff
         """
         if corpus is None and words is None:
             self.freq = pd.DataFrame()

--- a/dhlab/text/corpus.py
+++ b/dhlab/text/corpus.py
@@ -218,13 +218,13 @@ class Corpus(DhlabObj):
             ignore_caps=ignore_caps,
         )
 
-    def count(self, words=None, cutoff=0):
+    def count(self, words=None, cutoff=0, sparse=False):
         """Get word frequencies for corpus"""
-        return dh.Counts(self, words, cutoff)
+        return dh.Counts(self, words, cutoff, sparse)
 
-    def freq(self, words=None, cutoff=0):
+    def freq(self, words=None, cutoff=0, sparse=False):
         """Get word frequencies for corpus"""
-        return dh.Counts(self, words, cutoff)
+        return dh.Counts(self, words, cutoff, sparse)
 
     @staticmethod
     def _is_Corpus(corpus: "Corpus") -> bool:


### PR DESCRIPTION
Implements sparse matrices for counts:

```python
import dhlab as dh
corpus = dh.Corpus(doctype="digibok", limit=1000)

# with sparse matrix
cnt=corpus.count(sparse=True)

# without sparse matrix (this will probably not work on a 16 GB RAM laptop)
cnt=corpus.count()
```

Combined with cutoff, this could be a powerful option, especially for larger corpora.