### PR TITLE
set default doctype

### DIFF
--- a/dhlab/text/corpus.py
+++ b/dhlab/text/corpus.py
@@ -30,7 +30,7 @@ class Corpus(DhlabObj):
 
     def __init__(
         self,
-        doctype=None,
+        doctype="digibok",
         author=None,
         freetext=None,
         fulltext=None,


### PR DESCRIPTION
Books as default doctype when creating a DHLAB corpus.