### PR TITLE
Legg til enhetstester for `dhlab.api.nb_ngram_api`

### DIFF
--- a/tests/api/nb_ngram_api/test_get_ngram.py
+++ b/tests/api/nb_ngram_api/test_get_ngram.py
@@ -1,0 +1,24 @@
+import requests
+import unittest.mock
+from dhlab.api.nb_ngram_api import get_ngram
+import pytest
+
+
+@pytest.mark.parametrize(
+    "status_code", [404, 500, 504, 418,]
+)
+def test_empty_list_on_non_200_status(status_code: int) -> None:
+    """Empty list should be returned if the response status code is not 200"""
+    session = unittest.mock.MagicMock(spec=requests.Session)
+    session.get.return_value.status_code = status_code
+
+    assert get_ngram("test", session=session) == []
+
+
+def test_deserialised_on_200_status() -> None:
+    """Deserialised JSON should be returned if the response status code is 200"""
+    session = unittest.mock.MagicMock(spec=requests.Session)
+    session.get.return_value.status_code = 200
+    session.get.return_value.text = '[{"test_key": "test_value"}]'
+
+    assert get_ngram("test", session=session) == [{"test_key": "test_value"}]

--- a/tests/api/nb_ngram_api/test_make_word_graph.py
+++ b/tests/api/nb_ngram_api/test_make_word_graph.py
@@ -1,0 +1,46 @@
+import requests
+import unittest.mock
+from dhlab.api.nb_ngram_api import make_word_graph
+import json
+import networkx as nx
+from typing import Literal
+
+
+def _links_to_edge_view(nodes: list[str], links: list[dict[str, int]]) -> dict[tuple[str, str], dict[Literal["value", int]]]:
+    """Converts nodes and links as returned by the API to a dictionary with the same structure as nx.OutEdgeView
+
+    Example
+    -------
+    >>> _links_to_edge_view(["a", "b", "c"], links=[{"source": 0, "target": 2, "value": 3}])
+    {('a', 'c'): {'weight': 3}}
+    """
+    return {
+        (nodes[link["source"]]["name"], nodes[link["target"]]["name"]): {"weight": link["value"]}
+        for link in links
+    }
+
+def test_deserialises_di_graph() -> None:
+    """The word graph is deserialised correctly
+    """
+    data = {
+        "nodes": [
+            {"name": "askeladden", "size": 4},
+            {"name": "de", "size": 33},
+            {"name": "Rødrev", "size": 24},
+            {"name": "prinsessen", "size": 33},
+        ],
+        "links": [
+            {"source": 0, "target": 1, "value": 66},
+            {"source": 2, "target": 0, "value": 9},
+            {"source": 3, "target": 0, "value": 8},
+        ],
+    }
+
+    session = unittest.mock.MagicMock(spec=requests.Session)
+    session.get.return_value.status_code = 200
+    session.get.return_value.text = json.dumps(data)
+
+    word_graph = make_word_graph(words=["mocked", "data"], session=session)
+    assert len(word_graph.nodes) == len(data["nodes"])
+    assert set(word_graph.nodes) == {node["name"] for node in data["nodes"]}
+    assert dict(word_graph.edges) == _links_to_edge_view(data["nodes"], data["links"])


### PR DESCRIPTION
Denne PR-en legger til noen enhetstester for `dhlab.api.nb_ngram_api` modulen. To for `get_ngram` som sjekker oppførsel rundt statuskoder og en for `make_word_graph` som sjekker at JSON-deserialiseringen gjøres riktig.

For å styre oppførselen har jeg gjort en liten endring i logikken og latt funksjonene som gjør API-kall få inn et requests “session” objekt som input. Hvis det ikke sendes inn er så er oppførselen uendret, men hvis den sendes inn så brukes den til å kjøre HTTP-spørringene som lar oss kontrollere hva APIet skal returnere i testene. Dette er en form for dependency injection og er kjempenyttig for testing 🙂

Siden de `nb_ngram_api`-funksjonene nå tar et session-objekt som input kan vi f.eks. spesifisere hva APIet skal returnere og hvilken statuskode responsen skal få som gir oss full kontroll når vi tester.

Ellers så synes jeg det er litt pussig at flere funksjoner som snakker med APIet bare returnerer et tomt objekt dersom APIet f.eks. er nede. Hadde det ikke vært bedre å kommet med en eksplisitt feilmelding? Uansett, det er kanskje best å ha et eget issue for det! 
