### PR TITLE
Update Python from 3.9 to 3.12

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with: 
-          python-version: "3.9"
+          python-version: "3.12"
       - name: Permacache Poetry
         id: cache-poetry
         uses: actions/cache@v3
@@ -25,4 +25,4 @@ jobs:
         run: poetry install --with test
       - name: Test
         run: poetry run pytest tests --cov=dhlab
-  
+

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.10' 
+          python-version: '3.12'
       - name: Python Poetry Action
         uses: abatilo/actions-poetry@v3.0.0
       - name: Setup a local virtual environment

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.12"
 
       - name: Permacache Poetry
         id: cache-poetry

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.9", "3.10", "3.11", "3.12"]
+        python-version: [ "3.12"]
 
     steps:
       - uses: actions/checkout@v3

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -13,7 +13,7 @@ Head to our [official homepage](https://www.nb.no/dh-lab/) for tutorials, how-to
 
 ## Installation
 
-Ensure that you already have  [Python](https://www.python.org/downloads/) >=3.9 installed.
+Ensure that you already have  [Python](https://www.python.org/downloads/) >=3.12 installed.
 
 Install the latest version of the [`dhlab`](https://pypi.org/project/dhlab/) python package in your (Unix) terminal with pip:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ exclude = ["docs/", "tests/"]
 "Tutorials" = "https://nationallibraryofnorway.github.io/digital_tekstanalyse/tutorial.html"
 
 [tool.poetry.dependencies]
-python = ">=3.9"
+python = ">=3.12"
 ipython = "^8.17.2"
 matplotlib = "^3.8.1"
 networkx = "^3.2.1"
@@ -30,7 +30,7 @@ pandas = "^2.1.2"
 python-louvain = "^0.16"
 requests = "^2.31.0"
 seaborn = "^0.13.0"
-scipy = { version = "^1.11.3", python = ">=3.9,<3.13" }
+scipy = { version = "^1.11.3", python = ">=3.12,<3.13" }
 openpyxl = "^3.1.2"
 beautifulsoup4 = "^4.12.2"
 numpy = "^1.26.3"


### PR DESCRIPTION
Addresses Issue #225. Also makes #223 pass CI.

Python 3.10 also passes CI (with EOL at 2026-10 https://devguide.python.org/versions/), in case we don't want to go straight to 3.12.