### PR TITLE
update pyproject.toml to use pdm instead of poetry

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,6 +21,7 @@ jobs:
       - name: Install dependencies
         run: |
           pdm add -G test
+          pdm install
 
   
       - name: Run Tests

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,8 +20,8 @@ jobs:
   
       - name: Install dependencies
         run: |
-          pdm lock
-          pdm sync -d -G test
+          pdm add -G test
+
   
       - name: Run Tests
         run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,24 +5,23 @@ on: pull_request
 jobs:
   test:
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [ "3.10", "3.11", "3.12" ]
+
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with: 
-          python-version: "3.9"
-      - name: Permacache Poetry
-        id: cache-poetry
-        uses: actions/cache@v3
+      - uses: actions/checkout@v4
+      - name: Setup PDM
+        uses: pdm-project/setup-pdm@v4
         with:
-          path: ~/.poetry
-          key: poetry
-      - name: Install Poetry
-        if: steps.cache-poetry.outputs.cache-hit != 'true'
-        run: curl -sSL https://install.python-poetry.org | python - -y
-      - name: Add Poetry to path
-        run: echo "${HOME}/.poetry/bin" >> $GITHUB_PATH
-      - name: Install venv
-        run: poetry install --with test
-      - name: Test
-        run: poetry run pytest tests --cov=dhlab
+          python-version: ${{ matrix.python-version }}
   
+      - name: Install dependencies
+        run: |
+          pdm sync -d -G test
+  
+      - name: Run Tests
+        run: |
+          pdm run -v pytest tests --cov=dhlab

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,8 +20,9 @@ jobs:
   
       - name: Install dependencies
         run: |
+          pdm lock
           pdm sync -d -G test
   
       - name: Run Tests
         run: |
-          pdm run -v pytest tests --cov=dhlab
+          pdm run pytest -v tests --cov=dhlab

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,104 +1,76 @@
-[tool.poetry]
+[project]
 name = "dhlab"
 version = "2.41.0"
 description = "Text and image analysis of the digital collection (books, newspapers, periodicals, and images) at the National Library of Norway"
-authors = ["The Digital Humanities Lab at The National Library of Norway (NB) <dh-lab@nb.no>"]
-license = "MIT"
+authors = [
+    {name = "The Digital Humanities Lab at The National Library of Norway", email = "dh-lab@nb.no"}
+]
+license = {text = "MIT"}
 readme = "README.md"
-homepage = "https://www.nb.no/dh-lab/"
-documentation = "https://dhlab.readthedocs.io/en/stable/"
-repository = "https://github.com/NationalLibraryOfNorway/DHLAB"
+requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
-include = ["CHANGELOG.md", "LICENSE"]
-exclude = ["docs/", "tests/"]
-
-[tool.poetry.urls]
-"Bug Tracker" = "https://github.com/NationalLibraryOfNorway/DHLAB/issues"
-"Changelog" = "https://github.com/NationalLibraryOfNorway/DHLAB/blob/main/CHANGELOG.md"
-"Tutorials" = "https://nationallibraryofnorway.github.io/digital_tekstanalyse/tutorial.html"
-
-[tool.poetry.dependencies]
-python = ">=3.9"
-ipython = "^8.17.2"
-matplotlib = "^3.8.1"
-networkx = "^3.2.1"
-pandas = "^2.1.2"
-python-louvain = "^0.16"
-requests = "^2.31.0"
-seaborn = "^0.13.0"
-scipy = { version = "^1.11.3", python = ">=3.9,<3.13" }
-openpyxl = "^3.1.2"
-beautifulsoup4 = "^4.12.2"
-numpy = "^1.26.3"
-jinja2 = "^3.1.4"
-tqdm = "^4.66.6"
-
-[tool.poetry.group.docs.dependencies]
-Sphinx = "^7.2.6"
-furo = "^2023.9.10"
-myst-parser = "^2.0.0"
-readthedocs-sphinx-search = "^0.3.1"
-sphinx-copybutton = "^0.5.2"
-sphinx-togglebutton = "^0.3.2"
-sphinx_design = "^0.5.0"
-sphinx_inline_tabs = "^2023.4.21"
-mkdocs = "^1.5.2"
-mkdocstrings = {extras = ["python"], version = "^0.22.0"}
-mkdocs-material = "^9.1.21"
-mkdocs-section-index = "^0.3.5"
-mkdocs-autorefs = "^0.5.0"
-sphinx-autodoc2 = "^0.5.0"
-sphinx-book-theme = "^1.1.2"
-linkify-it-py = "^2.0.3"
-
-
-[tool.poetry.group.dev.dependencies]
-ipykernel = "^6.26.0"
-pytest = "^7.4.3"
-pytest-cov = "^4.1.0"
-mypy = "^1.6.1"
-black = "^23.10.1"
-isort = "^5.12.0"
-ruff = "^0.3.0"
-
-[tool.poetry.group.test.dependencies]
-mypy = "^1.6.1"
-pytest = "^7.4.3"
-pytest-cov = "^4.1.0"
-pytest-mock = "^3.12.0"
-
-[tool.poetry-dynamic-versioning]
-enable = false
-bump  = false
-vcs = "git"
-format = "v{base}{stage}{revision}"
-
-
-[tool.poetry-dynamic-versioning.substitution]
-files = ["dhlab/_version.py"]
-
-[build-system]
-requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning"]
-build-backend = "poetry_dynamic_versioning.backend"
-
-[tool.isort]
-profile = "black"
-
-[tool.mypy]
-files = "tests"
-mypy_path = "dhlab"
-namespace_packages = true
-explicit_package_bases = false
-show_error_codes = true
-warn_unused_configs = true
-strict = true
-enable_error_code = [
-    "ignore-without-code",
-    "redundant-expr",
-    "truthy-bool",
+dependencies = [
+    "ipython>=8.17.2",
+    "matplotlib>=3.8.1",
+    "networkx>=3.2.1",
+    "pandas>=2.2.3",
+    "python-louvain>=0.16",
+    "requests>=2.31.0",
+    "seaborn>=0.13.0",
+    "scipy>=1.15.1",
+    "openpyxl>=3.1.2",
+    "beautifulsoup4>=4.12.2",
+    "numpy>=2.2.1",
+    "jinja2>=3.1.4",
+    "tqdm>=4.66.6",
 ]
 
+[project.urls]
+Homepage = "https://www.nb.no/dh-lab/"
+Documentation = "https://nationallibraryofnorway.github.io/DHLAB/"
+Repository = "https://github.com/NationalLibraryOfNorway/DHLAB"
+Issues = "https://github.com/NationalLibraryOfNorway/DHLAB/issues"
+Tutorials = "https://nationallibraryofnorway.github.io/digital_tekstanalyse/tutorial.html"
+
+[project.optional-dependencies]
+docs = [
+    "Sphinx>=7.2.6",
+    "furo>=2023.9.10",
+    "myst-parser>=2.0.0",
+    "readthedocs-sphinx-search>=0.3.1",
+    "sphinx-copybutton>=0.5.2",
+    "sphinx-togglebutton>=0.3.2",
+    "sphinx_design>=0.5.0",
+    "sphinx_inline_tabs>=2023.4.21",
+    "mkdocs>=1.5.2",
+    "mkdocstrings[python]>=0.22.0",
+    "mkdocs-material>=9.1.21",
+    "mkdocs-section-index>=0.3.5",
+    "mkdocs-autorefs>=0.5.0",
+    "sphinx-autodoc2>=0.5.0",
+    "sphinx-book-theme>=1.1.2",
+    "linkify-it-py>=2.0.3",
+]
+dev = [
+    "ipykernel>=6.26.0",
+    "pytest>=7.4.3",
+    "pytest-cov>=4.1.0",
+    "mypy>=1.6.1",
+    "black>=23.10.1",
+    "isort>=5.12.0",
+    "ruff>=0.3.0",
+]
+test = [
+    "mypy>=1.6.1",
+    "pytest>=7.4.3",
+    "pytest-cov>=4.1.0",
+    "pytest-mock>=3.12.0",
+]
+
+[build-system]
+requires = ["pdm-backend"]
+build-backend = "pdm.backend"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ Repository = "https://github.com/NationalLibraryOfNorway/DHLAB"
 Issues = "https://github.com/NationalLibraryOfNorway/DHLAB/issues"
 Tutorials = "https://nationallibraryofnorway.github.io/digital_tekstanalyse/tutorial.html"
 
-[project.optional-dependencies]
+[dependency-groups]
 docs = [
     "Sphinx>=7.2.6",
     "furo>=2023.9.10",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
 ]
 license = {text = "MIT"}
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = "<3.13,>=3.10"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",
@@ -20,13 +20,13 @@ dependencies = [
     "pandas>=2.2.3",
     "python-louvain>=0.16",
     "requests>=2.31.0",
-    "seaborn>=0.13.0",
-    "scipy>=1.15.1",
+    "seaborn>=0.13.2",
+    "scipy==1.14",
     "openpyxl>=3.1.2",
     "beautifulsoup4>=4.12.2",
-    "numpy>=2.2.1",
     "jinja2>=3.1.4",
     "tqdm>=4.66.6",
+    "numpy==1.26",
 ]
 
 [project.urls]


### PR DESCRIPTION
# Additional changes
- Upgrade required python from 3.9 to 3.10
- ~~Upgrade scipy from 1.11 to 1.15~~
- ~~Upgrade numpy from 1.26 to 2.2~~ 
- Change "documentation" url from readthedocs to github pages
- `.github/workflows/CI.yml` uses pdm instead of poetry 