### PR TITLE
Rework tests

### DIFF
--- a/dhlab/api/dhlab_api.py
+++ b/dhlab/api/dhlab_api.py
@@ -59,14 +59,14 @@ def images(
     hits: int | None = 500,
     delta: int | None = 0,
     session: requests.Session | None = None
-):
+) -> list[str]:
     """Retrive images from bokhylla
 
     :param text: Fulltext query expression for sqlite.
     :param part: If a number, the whole page is shown. If True, get auto-scaled image.
     :param delta: If part==True, show `delta` additional pixels on each side of image
     :param hits: Number of images
-    :return: Requests `res.json()` return value
+    :return: List of image URLs
     """
 
     resp = api_get(

--- a/dhlab/api/dhlab_api.py
+++ b/dhlab/api/dhlab_api.py
@@ -817,8 +817,8 @@ def totals(top_words: int = 50000, session: requests.Session | None = None) -> D
 
 
 def concordance(
-    urns: list | None = None,
-    words: str | None = None,
+    urns: list,
+    words: str,
     window: int = 25,
     limit: int = 100,
     session: requests.Session | None = None
@@ -836,11 +836,8 @@ def concordance(
     :param int limit: max. number of concordances per document. Maximum value is 1000.
     :return: a table of concordances
     """
-    if words is None:
-        return pd.DataFrame(columns=["index", "docid", "urn", "conc"])  # exit condition
-    else:
-        params = {"urns": urns, "query": words, "window": window, "limit": limit}
-        r = api_post(BASE_URL + "/conc", json=params, session=session)
+    params = {"urns": urns, "query": words, "window": window, "limit": limit}
+    r = api_post(BASE_URL + "/conc", json=params, session=session)
     return pd.DataFrame(r.json())
 
 
@@ -848,8 +845,8 @@ konkordans = concordance # Function alias
 
 
 def concordance_counts(
-    urns: list | None = None,
-    words: str | None = None,
+    urns: list,
+    words: str,
     window: int = 25,
     limit: int = 100,
     session: requests.Session | None = None
@@ -867,11 +864,9 @@ def concordance_counts(
     :param int limit: max. number of concordances per document. Maximum value is 1000.
     :return: a table of counts
     """
-    if words is None:
-        return pd.DataFrame(columns=["freq"])  # exit condition
-    else:
-        params = {"urns": urns, "query": words, "window": window, "limit": limit}
-        r = api_post(BASE_URL + "/conccount", json=params, session=session)
+    params = {"urns": urns, "query": words, "window": window, "limit": limit}
+    r = api_post(BASE_URL + "/conccount", json=params, session=session)
+
     return pd.DataFrame(r.json())
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,8 @@ beautifulsoup4 = "^4.12.2"
 numpy = "^1.26.3"
 jinja2 = "^3.1.4"
 tqdm = "^4.66.6"
+typeguard = "^4.4.2"
+pandera = "^0.22.1"
 
 [tool.poetry.group.docs.dependencies]
 Sphinx = "^7.2.6"

--- a/tests/api/dhlab_api/test__ngram_doc.py
+++ b/tests/api/dhlab_api/test__ngram_doc.py
@@ -1,0 +1,12 @@
+import pytest
+
+import dhlab.api.dhlab_api as api
+from tests.api.dhlabtest import DHLabTest
+
+class Test_ngramDoc(DHLabTest):
+    @pytest.fixture(autouse=True)
+    def api_fn_fixture(self):
+        self.api_fn = self.init_api_fn(
+            api._ngram_doc,
+        )
+

--- a/tests/api/dhlab_api/test_collocation.py
+++ b/tests/api/dhlab_api/test_collocation.py
@@ -1,0 +1,12 @@
+import pytest
+
+import dhlab.api.dhlab_api as api
+from tests.api.dhlabtest import DHLabTest
+
+class TestCollocation(DHLabTest):
+    @pytest.fixture(autouse=True)
+    def api_fn_fixture(self):
+        self.api_fn = self.init_api_fn(
+            api.collocation,
+        )
+

--- a/tests/api/dhlab_api/test_concordance.py
+++ b/tests/api/dhlab_api/test_concordance.py
@@ -1,0 +1,13 @@
+import pytest
+
+import dhlab.api.dhlab_api as api
+from tests.api.utils import TEST_URN_DIGIBOK, TEST_WORDS_COMMA_SEPARATED
+from tests.api.dhlabtest import DHLabTest
+
+class TestConcordance(DHLabTest):
+    @pytest.fixture(autouse=True)
+    def api_fn_fixture(self):
+        self.api_fn = self.init_api_fn(
+            api.concordance, [TEST_URN_DIGIBOK, TEST_WORDS_COMMA_SEPARATED]
+        )
+

--- a/tests/api/dhlab_api/test_concordance.py
+++ b/tests/api/dhlab_api/test_concordance.py
@@ -1,13 +1,13 @@
 import pytest
 
 import dhlab.api.dhlab_api as api
-from tests.api.utils import TEST_URN_DIGIBOK, TEST_WORDS_COMMA_SEPARATED
+from tests.api.utils import TEST_URN_LIST, TEST_WORDS_COMMA_SEPARATED
 from tests.api.dhlabtest import DHLabTest
 
 class TestConcordance(DHLabTest):
     @pytest.fixture(autouse=True)
     def api_fn_fixture(self):
         self.api_fn = self.init_api_fn(
-            api.concordance, [TEST_URN_DIGIBOK, TEST_WORDS_COMMA_SEPARATED]
+            api.concordance, [TEST_URN_LIST, TEST_WORDS_COMMA_SEPARATED]
         )
 

--- a/tests/api/dhlab_api/test_concordance_counts.py
+++ b/tests/api/dhlab_api/test_concordance_counts.py
@@ -1,0 +1,13 @@
+import pytest
+
+import dhlab.api.dhlab_api as api
+from tests.api.utils import TEST_URN_LIST, TEST_WORDS_COMMA_SEPARATED
+from tests.api.dhlabtest import DHLabTest
+
+class TestConcordanceCounts(DHLabTest):
+    @pytest.fixture(autouse=True)
+    def api_fn_fixture(self):
+        self.api_fn = self.init_api_fn(
+            api.concordance_counts, [TEST_URN_LIST, TEST_WORDS_COMMA_SEPARATED]
+        )
+

--- a/tests/api/dhlab_api/test_document_corpus.py
+++ b/tests/api/dhlab_api/test_document_corpus.py
@@ -1,0 +1,12 @@
+import pytest
+
+import dhlab.api.dhlab_api as api
+from tests.api.dhlabtest import DHLabTest
+
+class TestDocumentCorpus(DHLabTest):
+    @pytest.fixture(autouse=True)
+    def api_fn_fixture(self):
+        self.api_fn = self.init_api_fn(
+            api.document_corpus,
+        )
+

--- a/tests/api/dhlab_api/test_evaluate_documents.py
+++ b/tests/api/dhlab_api/test_evaluate_documents.py
@@ -1,0 +1,12 @@
+import pytest
+
+import dhlab.api.dhlab_api as api
+from tests.api.dhlabtest import DHLabTest
+
+class TestEvaluateDocuments(DHLabTest):
+    @pytest.fixture(autouse=True)
+    def api_fn_fixture(self):
+        self.api_fn = self.init_api_fn(
+            api.evaluate_documents,
+        )
+

--- a/tests/api/dhlab_api/test_find_urns.py
+++ b/tests/api/dhlab_api/test_find_urns.py
@@ -1,0 +1,12 @@
+import pytest
+
+import dhlab.api.dhlab_api as api
+from tests.api.dhlabtest import DHLabTest
+
+class TestFindUrns(DHLabTest):
+    @pytest.fixture(autouse=True)
+    def api_fn_fixture(self):
+        self.api_fn = self.init_api_fn(
+            api.find_urns,
+        )
+

--- a/tests/api/dhlab_api/test_geo_lookup.py
+++ b/tests/api/dhlab_api/test_geo_lookup.py
@@ -1,0 +1,13 @@
+import pytest
+
+import dhlab.api.dhlab_api as api
+from tests.api.utils import TEST_PLACENAMES
+from tests.api.dhlabtest import DHLabTest
+
+class TestGeoLookup(DHLabTest):
+    @pytest.fixture(autouse=True)
+    def api_fn_fixture(self):
+        self.api_fn = self.init_api_fn(
+            api.geo_lookup, [TEST_PLACENAMES]
+        )
+

--- a/tests/api/dhlab_api/test_get_chunks.py
+++ b/tests/api/dhlab_api/test_get_chunks.py
@@ -1,0 +1,12 @@
+import pytest
+
+import dhlab.api.dhlab_api as api
+from tests.api.dhlabtest import DHLabTest
+
+class TestGetChunks(DHLabTest):
+    @pytest.fixture(autouse=True)
+    def api_fn_fixture(self):
+        self.api_fn = self.init_api_fn(
+            api.get_chunks,
+        )
+

--- a/tests/api/dhlab_api/test_get_chunks_para.py
+++ b/tests/api/dhlab_api/test_get_chunks_para.py
@@ -1,0 +1,12 @@
+import pytest
+
+import dhlab.api.dhlab_api as api
+from tests.api.dhlabtest import DHLabTest
+
+class TestGetChunksPara(DHLabTest):
+    @pytest.fixture(autouse=True)
+    def api_fn_fixture(self):
+        self.api_fn = self.init_api_fn(
+            api.get_chunks_para,
+        )
+

--- a/tests/api/dhlab_api/test_get_dispersion.py
+++ b/tests/api/dhlab_api/test_get_dispersion.py
@@ -1,0 +1,12 @@
+import pytest
+
+import dhlab.api.dhlab_api as api
+from tests.api.dhlabtest import DHLabTest
+
+class TestGetDispersion(DHLabTest):
+    @pytest.fixture(autouse=True)
+    def api_fn_fixture(self):
+        self.api_fn = self.init_api_fn(
+            api.get_dispersion,
+        )
+

--- a/tests/api/dhlab_api/test_get_document_corpus.py
+++ b/tests/api/dhlab_api/test_get_document_corpus.py
@@ -1,13 +1,13 @@
 import pytest
-
+from tests.api.utils import TestFunctionAlias
 import dhlab.api.dhlab_api as api
-from tests.api.dhlabtest import DHLabTest
 
-class TestGetDocumentCorpus(DHLabTest):
+class TestGetDocumentCorpus(TestFunctionAlias):
     @pytest.fixture(autouse=True)
-    def api_fn_fixture(self):
-        self.api_fn = self.init_api_fn(
-            api.get_document_corpus,
-            aliased_fn=api.document_corpus
-        )
+    def fn_alias(self):
+        self.fn_alias = api.get_document_corpus
+
+    @pytest.fixture(autouse=True)
+    def fn_orig(self):
+        self.fn_alias = api.get_document_corpus
 

--- a/tests/api/dhlab_api/test_get_document_corpus.py
+++ b/tests/api/dhlab_api/test_get_document_corpus.py
@@ -1,0 +1,13 @@
+import pytest
+
+import dhlab.api.dhlab_api as api
+from tests.api.dhlabtest import DHLabTest
+
+class TestGetDocumentCorpus(DHLabTest):
+    @pytest.fixture(autouse=True)
+    def api_fn_fixture(self):
+        self.api_fn = self.init_api_fn(
+            api.get_document_corpus,
+            aliased_fn=api.document_corpus
+        )
+

--- a/tests/api/dhlab_api/test_get_document_frequencies.py
+++ b/tests/api/dhlab_api/test_get_document_frequencies.py
@@ -1,0 +1,12 @@
+import pytest
+
+import dhlab.api.dhlab_api as api
+from tests.api.dhlabtest import DHLabTest
+
+class TestGetDocumentFrequencies(DHLabTest):
+    @pytest.fixture(autouse=True)
+    def api_fn_fixture(self):
+        self.api_fn = self.init_api_fn(
+            api.get_document_frequencies,
+        )
+

--- a/tests/api/dhlab_api/test_get_identifiers.py
+++ b/tests/api/dhlab_api/test_get_identifiers.py
@@ -1,0 +1,12 @@
+import pytest
+
+import dhlab.api.dhlab_api as api
+from tests.api.dhlabtest import DHLabTest
+
+class TestGetIdentifiers(DHLabTest):
+    @pytest.fixture(autouse=True)
+    def api_fn_fixture(self):
+        self.api_fn = self.init_api_fn(
+            api.get_identifiers,
+        )
+

--- a/tests/api/dhlab_api/test_get_metadata.py
+++ b/tests/api/dhlab_api/test_get_metadata.py
@@ -1,0 +1,12 @@
+import pytest
+
+import dhlab.api.dhlab_api as api
+from tests.api.dhlabtest import DHLabTest
+
+class TestGetMetadata(DHLabTest):
+    @pytest.fixture(autouse=True)
+    def api_fn_fixture(self):
+        self.api_fn = self.init_api_fn(
+            api.get_metadata,
+        )
+

--- a/tests/api/dhlab_api/test_get_places.py
+++ b/tests/api/dhlab_api/test_get_places.py
@@ -1,0 +1,13 @@
+import pytest
+
+import dhlab.api.dhlab_api as api
+from tests.api.utils import TEST_URN_DIGIBOK
+from tests.api.dhlabtest import DHLabTest
+
+class TestGetPlaces(DHLabTest):
+    @pytest.fixture(autouse=True)
+    def api_fn_fixture(self):
+        self.api_fn = self.init_api_fn(
+            api.get_places, [TEST_URN_DIGIBOK]
+        )
+

--- a/tests/api/dhlab_api/test_get_reference.py
+++ b/tests/api/dhlab_api/test_get_reference.py
@@ -1,0 +1,12 @@
+import pytest
+
+import dhlab.api.dhlab_api as api
+from tests.api.dhlabtest import DHLabTest
+
+class TestGetReference(DHLabTest):
+    @pytest.fixture(autouse=True)
+    def api_fn_fixture(self):
+        self.api_fn = self.init_api_fn(
+            api.get_reference,
+        )
+

--- a/tests/api/dhlab_api/test_get_urn_frequencies.py
+++ b/tests/api/dhlab_api/test_get_urn_frequencies.py
@@ -1,0 +1,12 @@
+import pytest
+
+import dhlab.api.dhlab_api as api
+from tests.api.dhlabtest import DHLabTest
+
+class TestGetUrnFrequencies(DHLabTest):
+    @pytest.fixture(autouse=True)
+    def api_fn_fixture(self):
+        self.api_fn = self.init_api_fn(
+            api.get_urn_frequencies,
+        )
+

--- a/tests/api/dhlab_api/test_get_word_frequencies.py
+++ b/tests/api/dhlab_api/test_get_word_frequencies.py
@@ -1,0 +1,12 @@
+import pytest
+
+import dhlab.api.dhlab_api as api
+from tests.api.dhlabtest import DHLabTest
+
+class TestGetWordFrequencies(DHLabTest):
+    @pytest.fixture(autouse=True)
+    def api_fn_fixture(self):
+        self.api_fn = self.init_api_fn(
+            api.get_word_frequencies,
+        )
+

--- a/tests/api/dhlab_api/test_images.py
+++ b/tests/api/dhlab_api/test_images.py
@@ -1,0 +1,12 @@
+import pytest
+
+import dhlab.api.dhlab_api as api
+from tests.api.dhlabtest import DHLabTest
+
+class TestImages(DHLabTest):
+    @pytest.fixture(autouse=True)
+    def api_fn_fixture(self):
+        self.api_fn = self.init_api_fn(
+            api.images,
+        )
+

--- a/tests/api/dhlab_api/test_konkordans.py
+++ b/tests/api/dhlab_api/test_konkordans.py
@@ -1,0 +1,13 @@
+import pytest
+
+import dhlab.api.dhlab_api as api
+from tests.api.dhlabtest import DHLabTest
+
+class TestKonkordans(DHLabTest):
+    @pytest.fixture(autouse=True)
+    def api_fn_fixture(self):
+        self.api_fn = self.init_api_fn(
+            api.konkordans,
+            aliased_fn=api.concordance
+        )
+

--- a/tests/api/dhlab_api/test_konkordans.py
+++ b/tests/api/dhlab_api/test_konkordans.py
@@ -1,13 +1,13 @@
 import pytest
-
+from tests.api.utils import TestFunctionAlias
 import dhlab.api.dhlab_api as api
-from tests.api.dhlabtest import DHLabTest
 
-class TestKonkordans(DHLabTest):
+class TestGetDocumentCorpus(TestFunctionAlias):
     @pytest.fixture(autouse=True)
-    def api_fn_fixture(self):
-        self.api_fn = self.init_api_fn(
-            api.konkordans,
-            aliased_fn=api.concordance
-        )
+    def fn_alias(self):
+        self.fn_alias = api.konkordans
+
+    @pytest.fixture(autouse=True)
+    def fn_orig(self):
+        self.fn_alias = api.concordance
 

--- a/tests/api/dhlab_api/test_ner_from_urn.py
+++ b/tests/api/dhlab_api/test_ner_from_urn.py
@@ -1,0 +1,12 @@
+import pytest
+
+import dhlab.api.dhlab_api as api
+from tests.api.dhlabtest import DHLabTest
+
+class TestNerFromUrn(DHLabTest):
+    @pytest.fixture(autouse=True)
+    def api_fn_fixture(self):
+        self.api_fn = self.init_api_fn(
+            api.ner_from_urn,
+        )
+

--- a/tests/api/dhlab_api/test_ngram_book.py
+++ b/tests/api/dhlab_api/test_ngram_book.py
@@ -1,0 +1,12 @@
+import pytest
+
+import dhlab.api.dhlab_api as api
+from tests.api.dhlabtest import DHLabTest
+
+class TestNgramBook(DHLabTest):
+    @pytest.fixture(autouse=True)
+    def api_fn_fixture(self):
+        self.api_fn = self.init_api_fn(
+            api.ngram_book,
+        )
+

--- a/tests/api/dhlab_api/test_ngram_news.py
+++ b/tests/api/dhlab_api/test_ngram_news.py
@@ -1,0 +1,12 @@
+import pytest
+
+import dhlab.api.dhlab_api as api
+from tests.api.dhlabtest import DHLabTest
+
+class TestNgramNews(DHLabTest):
+    @pytest.fixture(autouse=True)
+    def api_fn_fixture(self):
+        self.api_fn = self.init_api_fn(
+            api.ngram_news,
+        )
+

--- a/tests/api/dhlab_api/test_ngram_periodicals.py
+++ b/tests/api/dhlab_api/test_ngram_periodicals.py
@@ -1,0 +1,12 @@
+import pytest
+
+import dhlab.api.dhlab_api as api
+from tests.api.dhlabtest import DHLabTest
+
+class TestNgramPeriodicals(DHLabTest):
+    @pytest.fixture(autouse=True)
+    def api_fn_fixture(self):
+        self.api_fn = self.init_api_fn(
+            api.ngram_periodicals,
+        )
+

--- a/tests/api/dhlab_api/test_pos_from_urn.py
+++ b/tests/api/dhlab_api/test_pos_from_urn.py
@@ -1,0 +1,12 @@
+import pytest
+
+import dhlab.api.dhlab_api as api
+from tests.api.dhlabtest import DHLabTest
+
+class TestPosFromUrn(DHLabTest):
+    @pytest.fixture(autouse=True)
+    def api_fn_fixture(self):
+        self.api_fn = self.init_api_fn(
+            api.pos_from_urn,
+        )
+

--- a/tests/api/dhlab_api/test_query_imagination_corpus.py
+++ b/tests/api/dhlab_api/test_query_imagination_corpus.py
@@ -1,0 +1,12 @@
+import dhlab.api.dhlab_api as api
+from tests.api.dhlabtest import DHLabTest
+
+import pytest
+
+class TestQueryImaginationCorpus(DHLabTest):
+    @pytest.fixture(autouse=True)
+    def api_fn_fixture(self):
+        self.api_fn = self.init_api_fn(
+            api.query_imagination_corpus,
+        )
+

--- a/tests/api/dhlab_api/test_reference_words.py
+++ b/tests/api/dhlab_api/test_reference_words.py
@@ -1,0 +1,12 @@
+import pytest
+
+import dhlab.api.dhlab_api as api
+from tests.api.dhlabtest import DHLabTest
+
+class TestReferenceWords(DHLabTest):
+    @pytest.fixture(autouse=True)
+    def api_fn_fixture(self):
+        self.api_fn = self.init_api_fn(
+            api.reference_words,
+        )
+

--- a/tests/api/dhlab_api/test_show_spacy_models.py
+++ b/tests/api/dhlab_api/test_show_spacy_models.py
@@ -1,0 +1,12 @@
+import pytest
+
+import dhlab.api.dhlab_api as api
+from tests.api.dhlabtest import DHLabTest
+
+class TestShowSpacyModels(DHLabTest):
+    @pytest.fixture(autouse=True)
+    def api_fn_fixture(self):
+        self.api_fn = self.init_api_fn(
+            api.show_spacy_models,
+        )
+

--- a/tests/api/dhlab_api/test_totals.py
+++ b/tests/api/dhlab_api/test_totals.py
@@ -1,0 +1,12 @@
+import pytest
+
+import dhlab.api.dhlab_api as api
+from tests.api.dhlabtest import DHLabTest
+
+class TestTotals(DHLabTest):
+    @pytest.fixture(autouse=True)
+    def api_fn_fixture(self):
+        self.api_fn = self.init_api_fn(
+            api.totals,
+        )
+

--- a/tests/api/dhlab_api/test_urn_collocation.py
+++ b/tests/api/dhlab_api/test_urn_collocation.py
@@ -1,0 +1,12 @@
+import pytest
+
+import dhlab.api.dhlab_api as api
+from tests.api.dhlabtest import DHLabTest
+
+class TestUrnCollocation(DHLabTest):
+    @pytest.fixture(autouse=True)
+    def api_fn_fixture(self):
+        self.api_fn = self.init_api_fn(
+            api.urn_collocation,
+        )
+

--- a/tests/api/dhlab_api/test_wildcard_search.py
+++ b/tests/api/dhlab_api/test_wildcard_search.py
@@ -1,0 +1,25 @@
+import pytest
+import pandera as pa
+
+import dhlab.api.dhlab_api as api
+from tests.api.dhlabtest import DHLabTest
+
+class TestWildcardSearch(DHLabTest):
+    @pytest.fixture(autouse=True)
+    def api_fn_fixture(self):
+        self.api_fn = self.init_api_fn(
+            api.wildcard_search,
+            args=["ord*en*"]
+        )
+
+    def test_returned_df_schema(self):
+        ret = self.call_api_fn()
+
+        # Docstring assumes this dataframe schema:
+        schema = pa.DataFrameSchema(
+            {"freq": pa.Column(int)},
+            index=pa.Index(str)
+        )
+
+        schema.validate(ret)
+

--- a/tests/api/dhlab_api/test_word_form.py
+++ b/tests/api/dhlab_api/test_word_form.py
@@ -1,0 +1,13 @@
+import pytest
+
+import dhlab.api.dhlab_api as api
+from tests.api.utils import TEST_WORD
+from tests.api.dhlabtest import DHLabTest
+
+class TestWordForm(DHLabTest):
+    @pytest.fixture(autouse=True)
+    def api_fn_fixture(self):
+        self.api_fn = self.init_api_fn(
+            api.word_form, [TEST_WORD]
+        )
+

--- a/tests/api/dhlab_api/test_word_form_many.py
+++ b/tests/api/dhlab_api/test_word_form_many.py
@@ -1,0 +1,13 @@
+import pytest
+
+import dhlab.api.dhlab_api as api
+from tests.api.utils import TEST_WORDS
+from tests.api.dhlabtest import DHLabTest
+
+class TestWordFormMany(DHLabTest):
+    @pytest.fixture(autouse=True)
+    def api_fn_fixture(self):
+        self.api_fn = self.init_api_fn(
+            api.word_form_many, [TEST_WORDS]
+        )
+

--- a/tests/api/dhlab_api/test_word_lemma.py
+++ b/tests/api/dhlab_api/test_word_lemma.py
@@ -1,0 +1,13 @@
+import pytest
+
+import dhlab.api.dhlab_api as api
+from tests.api.utils import TEST_WORD
+from tests.api.dhlabtest import DHLabTest
+
+class TestWordLemma(DHLabTest):
+    @pytest.fixture(autouse=True)
+    def api_fn_fixture(self):
+        self.api_fn = self.init_api_fn(
+            api.word_lemma, [TEST_WORD]
+        )
+

--- a/tests/api/dhlab_api/test_word_paradigm.py
+++ b/tests/api/dhlab_api/test_word_paradigm.py
@@ -1,0 +1,13 @@
+import pytest
+
+import dhlab.api.dhlab_api as api
+from tests.api.utils import TEST_WORD
+from tests.api.dhlabtest import DHLabTest
+
+class TestWordParadigm(DHLabTest):
+    @pytest.fixture(autouse=True)
+    def api_fn_fixture(self):
+        self.api_fn = self.init_api_fn(
+            api.word_paradigm, [TEST_WORD]
+        )
+

--- a/tests/api/dhlab_api/test_word_paradigm_many.py
+++ b/tests/api/dhlab_api/test_word_paradigm_many.py
@@ -1,0 +1,13 @@
+import pytest
+
+import dhlab.api.dhlab_api as api
+from tests.api.utils import TEST_WORDS
+from tests.api.dhlabtest import DHLabTest
+
+class TestWordParadigmMany(DHLabTest):
+    @pytest.fixture(autouse=True)
+    def api_fn_fixture(self):
+        self.api_fn = self.init_api_fn(
+            api.word_paradigm_many, [TEST_WORDS]
+        )
+

--- a/tests/api/dhlab_api/test_word_variant.py
+++ b/tests/api/dhlab_api/test_word_variant.py
@@ -1,0 +1,12 @@
+import pytest
+
+import dhlab.api.dhlab_api as api
+from tests.api.dhlabtest import DHLabTest
+
+class TestWordVariant(DHLabTest):
+    @pytest.fixture(autouse=True)
+    def api_fn_fixture(self):
+        self.api_fn = self.init_api_fn(
+            api.word_variant, ['spiste', 'pres-part']
+        )
+

--- a/tests/api/dhlabtest.py
+++ b/tests/api/dhlabtest.py
@@ -1,0 +1,85 @@
+from abc import ABC, abstractmethod
+import functools
+from typing import Any, Callable, Protocol
+from unittest.mock import MagicMock
+import warnings
+import inspect
+import pytest
+import requests
+from typeguard import typechecked
+from dhlab.api.utils import DHLabApiError
+import tests.api.utils as apitest
+
+
+@pytest.fixture(params=(404, 500, 504, 418,))
+def _error_status_code(request):
+    return request.param
+
+class DHLabTest(ABC):
+    api_ret = {}
+
+    @abstractmethod
+    @pytest.fixture(autouse=True)
+    def api_fn_fixture(self) -> functools.partial:
+        """Set api_fn to be tested. Should usually be called with set_api_fn."""
+        ...
+
+    @staticmethod
+    def _test_alias_fn(fn_alias: Callable, fn_orig: Callable):
+        assert inspect.isfunction(fn_alias)
+        assert inspect.isfunction(fn_orig)
+        assert fn_alias is fn_orig
+
+        # TODO: assert original function is tested?
+
+    @staticmethod
+    def init_api_fn(
+        api_fn: Callable,
+        args: list | None = None,
+        kwargs: dict[str, Any] | None = None,
+        typecheck: bool = True,
+        aliased_fn: Callable | None = None,
+    ):
+        """api_fn needs to be defined as a pytest fixture in every file containing an inheriting class."""
+        if aliased_fn:
+            DHLabTest._test_alias_fn(api_fn, aliased_fn)
+            pytest.skip(allow_module_level=True)
+
+        if args is None:
+            args = []
+        if kwargs is None:
+            kwargs = {}
+
+        if typecheck:
+            api_fn = functools.wraps(api_fn)(typechecked(api_fn))
+
+        return functools.partial(api_fn, *args, **kwargs)
+
+    def call_api_fn(self, _cache: bool = True, **kwargs):
+        if _cache:
+            cache_key = frozenset(kwargs.items())
+            if cache_key in self.api_ret:
+                return self.api_ret[cache_key]
+
+        try:
+            ret = self.api_fn(**kwargs)
+        except DHLabApiError:
+            # args/kwargs from the partial function are shown at `{self.api_fn}`
+            warnings.warn(f"Server error when calling {self.api_fn}, {kwargs=}. Skipping test.")
+            pytest.skip()
+
+        if _cache:
+            self.api_ret[cache_key] = ret
+
+        return ret
+
+    @pytest.mark.parametrize("error_status_code", (404, 500, 504, 418,))
+    def test_error_status_codes(self, error_status_code):
+        mock_response = MagicMock(spec=requests.Response)
+        mock_response.reason = "Mocked reason"
+        mock_response.status_code = error_status_code
+        session = apitest.mock_api_call(response=mock_response)
+
+        with pytest.raises(DHLabApiError):
+            self.api_fn(session=session)
+

--- a/tests/api/dhlabtest.py
+++ b/tests/api/dhlabtest.py
@@ -3,7 +3,6 @@ import functools
 from typing import Any, Callable
 from unittest.mock import MagicMock
 import warnings
-import inspect
 import pytest
 import requests
 from typeguard import typechecked
@@ -21,26 +20,13 @@ class DHLabTest(ABC):
         ...
 
     @staticmethod
-    def _test_alias_fn(fn_alias: Callable, fn_orig: Callable):
-        assert inspect.isfunction(fn_alias)
-        assert inspect.isfunction(fn_orig)
-        assert fn_alias is fn_orig
-
-        # TODO: assert original function is tested?
-
-    @staticmethod
     def init_api_fn(
         api_fn: Callable,
         args: list | None = None,
         kwargs: dict[str, Any] | None = None,
         typecheck: bool = True,
-        aliased_fn: Callable | None = None,
     ):
         """api_fn needs to be defined as a pytest fixture in every file containing an inheriting class."""
-        if aliased_fn:
-            DHLabTest._test_alias_fn(api_fn, aliased_fn)
-            pytest.skip(allow_module_level=True)
-
         if args is None:
             args = []
         if kwargs is None:

--- a/tests/api/dhlabtest.py
+++ b/tests/api/dhlabtest.py
@@ -61,7 +61,7 @@ class DHLabTest(ABC):
             ret = self.api_fn(**kwargs)
         except DHLabApiError:
             # args/kwargs from the partial function are shown at `{self.api_fn}`
-            warnings.warn(f"Server error when calling {self.api_fn}, {kwargs=}. Skipping test.")
+            warnings.warn(f"Server error when calling {self.api_fn}, extra kwargs: {kwargs}. Skipping test.")
             pytest.skip()
 
         if _cache:

--- a/tests/api/dhlabtest.py
+++ b/tests/api/dhlabtest.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 import functools
-from typing import Any, Callable, Protocol
+from typing import Any, Callable
 from unittest.mock import MagicMock
 import warnings
 import inspect
@@ -10,10 +10,6 @@ from typeguard import typechecked
 from dhlab.api.utils import DHLabApiError
 import tests.api.utils as apitest
 
-
-@pytest.fixture(params=(404, 500, 504, 418,))
-def _error_status_code(request):
-    return request.param
 
 class DHLabTest(ABC):
     api_ret = {}

--- a/tests/api/dhlabtest.py
+++ b/tests/api/dhlabtest.py
@@ -83,3 +83,6 @@ class DHLabTest(ABC):
         with pytest.raises(DHLabApiError):
             self.api_fn(session=session)
 
+    def test_call(self):
+        self.call_api_fn(_cache=False)
+

--- a/tests/api/utils.py
+++ b/tests/api/utils.py
@@ -1,0 +1,56 @@
+import requests
+from unittest.mock import MagicMock
+
+
+def _mocked_request_fn(
+    request_fn,
+    response: requests.Response,
+    methods: list[str] | None = None,
+    urls: list[str] | None = None,
+):
+    def wrapped_request_fn(*args, **kwargs) -> requests.Response:
+        method = args[0] if len(args) > 0 else kwargs['method']
+        url =    args[1] if len(args) > 1 else kwargs['url']
+
+        if (methods is None or method in methods) and (urls is None or url in urls):
+            resp = response
+        else:
+            resp = request_fn(*args, **kwargs)
+
+        return resp
+            
+    return wrapped_request_fn
+
+def mock_api_call(
+    method: str | list[str] | None = None,
+    url: str | list[str] | None = None,
+    response: requests.Response | None = None,
+    session: requests.Session | None = None,
+) -> requests.Session:
+    """Abstract away api-calling implementation details
+
+    Modifies the passed `session`.
+
+    :param method: Methods to mock the calls of (`"POST"`, `"GET"`, ...). If `None`, mock all calls.
+    :param url: Urls to mock the calls of. If `None`, mock all calls.
+    :param response: Desired response from api call. If `None`, initialized as `MagicMock(spec=Response())`
+    :param session: `requests.Session` instance to modify. If `None`, create new `Session`.
+
+    :return: Modified `session`.
+    """
+    if session is None:
+        session = requests.Session()
+
+    if response is None:
+        response = MagicMock(spec=requests.Response)
+
+    if isinstance(method, str):
+        method = [method]
+    if isinstance(url, str):
+        url = [url]
+
+    # XXX: Overwrites original session instance
+    session.request = _mocked_request_fn(session.request, response, method, url)
+
+    return session
+

--- a/tests/api/utils.py
+++ b/tests/api/utils.py
@@ -1,6 +1,13 @@
 import requests
 from unittest.mock import MagicMock
 
+TEST_URN_DIGIBOK = "URN:NBN:no-nb_digibok_2008091004038"
+TEST_URN_LIST = [TEST_URN_DIGIBOK] # TODO: Add more URNs
+TEST_PLACENAMES = ["Oslo", "London"]
+TEST_WORDS = ["og", "eller"]
+TEST_WORDS_COMMA_SEPARATED = ",".join(TEST_WORDS)
+TEST_WORD = TEST_WORDS[0]
+INVALID_URN = "Invalid URN 36b43144-94fc-43b2-ba26-f67570a217d9" # Randomly generated UUID
 
 def _mocked_request_fn(
     request_fn,

--- a/tests/api/utils.py
+++ b/tests/api/utils.py
@@ -1,3 +1,6 @@
+from abc import abstractmethod
+from typing import Callable
+import pytest
 import requests
 from unittest.mock import MagicMock
 
@@ -60,4 +63,20 @@ def mock_api_call(
     session.request = _mocked_request_fn(session.request, response, method, url)
 
     return session
+
+class TestFunctionAlias():
+    @abstractmethod
+    @pytest.fixture(autouse=True)
+    def fn_alias(self):
+        ...
+
+    @abstractmethod
+    @pytest.fixture(autouse=True)
+    def fn_orig(self):
+        ...
+
+    def test_alias_fn(self, fn_alias: Callable, fn_orig: Callable):
+        assert fn_alias is fn_orig
+
+        # TODO: assert original function is tested?
 


### PR DESCRIPTION
Tester for `dhlab/api/dhlab_api.py`.

Kan kanskje generaliseres (eller bare endre navn?) for å brukes med andre api-moduler, som f.eks. `dhlab/api/nb_ngram_api.py`.

Har ikke enda lagt til så mange ikke-generiske tester, siden jeg ville høre om denne strukturen virker ok først.

Brancher ut fra #246 (og #244).

Oversikt over bruk av testene:

- `DHLabTest` classen inneholder generiske tester som alle api-funksjoner vanligvis bør kjøre
- Hver enkelte api test lager en egen fil, med (f.eks.) en `class TestConcordance(DHLabTest)`, som bare trenger å legge til en slik `fixture` for å fungere med alle testene i `DHLabTest`:
```py
class TestGeoLookup(DHLabTest):
    @pytest.fixture(autouse=True)
    def api_fn_fixture(self):
        self.api_fn = self.init_api_fn(
            api.geo_lookup, [TEST_PLACENAMES]
        )
```
Bare kom med forslag hvis noen har en penere måte å gjøre dette på :) Liker ikke helt dette selv, men er ikke helt sikker på hvordan det kan gjøres bedre med pytest test-klasser, siden de ikke tillater en `__init__`-funksjon.
- `self.api_fn` skal være en `functools.partial`.
- Eksempel på ekstra/"ikke-generiske" tester:

```py
class TestWildcardSearch(DHLabTest):
    @pytest.fixture(autouse=True)
    def api_fn_fixture(self):
        self.api_fn = self.init_api_fn(
            api.wildcard_search,
            args=["ord*en*"]
        )

    def test_returned_df_schema(self):
        ret = self.call_api_fn()

        # Docstring assumes this dataframe schema:
        schema = pa.DataFrameSchema(
            {"freq": pa.Column(int)},
            index=pa.Index(str)
        )

        schema.validate(ret)
```
- Alias-funksjoner (`func2 = func1`) bruker `TestFunctionAlias` i `tests/api/utils.py`. Denne er kanskje ikke veldig nyttig, men jeg vurderte å legge til en test som gir en warning hvis en av api-funksjonene i `dhlab/api/dhlab_api.py` ikke er testet, så tenkte det var bedre enn bare en `pass`, men kanskje bedre å fjerne den? Eksempel:
```py
class TestGetDocumentCorpus(TestFunctionAlias):
    @pytest.fixture(autouse=True)
    def fn_alias(self):
        self.fn_alias = api.get_document_corpus

    @pytest.fixture(autouse=True)
    def fn_orig(self):
        self.fn_alias = api.get_document_corpus
```

Vi har snakket om å ikke teste selve nett-apiet, men jeg la til en `test_call` for å sjekke at endpointet går gjennom med argumentene som python-wrapper forventer. `return`-verdiene blir også type-checked. Jeg kunne evt. lagt til et flag man kan sende til pytest for å slå av/på tester som faktisk kaller nett-apiet. Testene som kaller nett-apiet gir dog bare en `warning` og blir hoppet over med `pytest.skip` dersom den får en `DHLabApiError`, istedenfor å gi `Error`/`Fail`.