### PR TITLE
Ignore files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,6 +158,8 @@ dhlab/_version.py
 # project management
 *.lock
 .pdm-python
+.pdm-build
+.*_cache
 
 # documentation legacy files
 docs/new_conf.py

--- a/.gitignore
+++ b/.gitignore
@@ -154,6 +154,11 @@ dhlab/_version.py
 
 # vscode settings
 .vscode
-poetry.lock
+
+# project management
+*.lock
+.pdm-python
+
+# documentation legacy files
 docs/new_conf.py
 docs/orig_conf.py


### PR DESCRIPTION
Jeg har bare lagt til en del filer jeg vanligvis irriterer meg over når git flagger at de har endret seg. 

- `*.lock`-filer: iom. at `dhlab` er et bibliotek som bør fungere med ulike python-versjoner og andre tredjepartsavhengigheter, holder det å spesifisere det i pyproject.toml
- cache-mapper: alt som genereres av cache-filer og som er venv-spesifikt bør holdes utenfor versjonskontrollen