### PR TITLE
add wordcloud + scipy as dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,8 @@ dependencies = [
     "tqdm",
     "nb-tokenizer",
     "lazy-loader",
+    "wordcloud",
+    "scipy",
 ]
 name = "dhlab"
 version = "2.42.0"


### PR DESCRIPTION
Resolves #229. Additionally, adds scipy as a dependency since it is used for NB N-gram.