### PR TITLE
Add unigram parameter to corpus builder

### DIFF
--- a/dhlab/api/dhlab_api.py
+++ b/dhlab/api/dhlab_api.py
@@ -645,6 +645,7 @@ def document_corpus(
     author: str | None = None,
     freetext: str | None = None,
     fulltext: str | None = None,
+    unigram: str | None = None,
     from_year: int | None = None,
     to_year: int | None = None,
     from_timestamp: int | None = None,
@@ -670,7 +671,8 @@ def document_corpus(
     :param str doctype: ``"digibok"``, ``"digavis"``, ``"digitidsskrift"`` or ``"digistorting"``
     :param str author: Name of an author.
     :param str freetext: any of the parameters, for example: ``"digibok AND Ibsen"``.
-    :param str fulltext: words within the publication.
+    :param str fulltext: fulltext within the publication.
+    :param str unigram: words within the publication.
     :param int from_year: Start year for time period of interest.
     :param int to_year: End year for time period of interest.
     :param int from_timestamp: Start date for time period of interest.
@@ -692,7 +694,7 @@ def document_corpus(
     :return: a ``pandas.DataFrame`` with the corpus information.
     """
     parms = {"doctype": doctype, "author": author, "freetext": freetext,
-             "fulltext": fulltext, "from_year": from_year, "to_year": to_year,
+             "fulltext": fulltext, "unigram": unigram, "from_year": from_year, "to_year": to_year,
              "from_timestamp": from_timestamp, "to_timestamp": to_timestamp,
              "title": title, "ddk": ddk, "subject": subject, "publisher": publisher,
              "literaryform": literaryform, "genres": genres, "city": city,

--- a/dhlab/text/corpus.py
+++ b/dhlab/text/corpus.py
@@ -36,6 +36,7 @@ class Corpus(DhlabObj):
         author: str | None = None,
         freetext: str | None = None,
         fulltext: str | None = None,
+        unigram: str | None = None,
         from_year: int | None = None,
         to_year: int | None = None,
         from_timestamp: int | None = None,
@@ -60,7 +61,8 @@ class Corpus(DhlabObj):
         :param str author: Name of an author.
         :param str freetext: any of the parameters, for example:\
             ``"digibok AND Ibsen"``.
-        :param str fulltext: words within the publication.
+        :param str fulltext: fulltext within the publication.
+        :param str unigram: words within the publication.
         :param int from_year: Start year for time period of interest.
         :param int to_year: End year for time period of interest.
         :param int from_timestamp: Start date for time period of interest.
@@ -87,6 +89,7 @@ class Corpus(DhlabObj):
             or author
             or freetext
             or fulltext
+            or unigram
             or from_year
             or to_year
             or from_timestamp
@@ -114,6 +117,7 @@ class Corpus(DhlabObj):
                         author,
                         freetext,
                         fulltext,
+                        unigram,
                         from_year,
                         to_year,
                         from_timestamp,
@@ -140,6 +144,7 @@ class Corpus(DhlabObj):
                     author,
                     freetext,
                     fulltext,
+                    unigram,
                     from_year,
                     to_year,
                     from_timestamp,


### PR DESCRIPTION
This PR adds support for the API unigram parameter of the corpus builder, allowing the user to build corpora from unigrams (faster), instead of using slower, but more powerful fulltext search.